### PR TITLE
fix filename regex

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,5 +5,5 @@ export const sleep = (ms: number): Promise<void> => {
 }
 
 export const toFilename = (s: string): string => {
-  return s.replace(/[/\\?%*:|"<>]/g, '-');
+  return s.replace(/[/\\%*:|"<>]/g, '-');
 }


### PR DESCRIPTION
Fixed a regular expression problem.

Filename may contain "?" such as "How does Matter Obsidian plugin Works?" and question marks in filename may be replaced with "-" by current regular expression.