### PR TITLE
Add tags and publisher name in metadata

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -25,10 +25,16 @@ export interface Publisher {
   any_name: string | null;
 }
 
+export interface Tag {
+  created_date: string;
+  name: string;
+}
+
 export interface Content {
   author: Author;
   publisher: Publisher;
   my_annotations: Annotation[];
+  tags: Tag[];
   publication_date: string;
   title: string;
   url: string;

--- a/src/api.ts
+++ b/src/api.ts
@@ -21,8 +21,13 @@ export interface Author {
   any_name: string | null;
 }
 
+export interface Publisher {
+  any_name: string | null;
+}
+
 export interface Content {
   author: Author;
+  publisher: Publisher;
   my_annotations: Annotation[];
   publication_date: string;
   title: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -226,6 +226,13 @@ ${annotations.map(this._renderAnnotation).join("\n")}
       metadata += `\n* Publisher: [[${feedEntry.content.publisher.any_name}]]`;
     }
 
+    if (feedEntry.content.tags.length != 0) {
+      metadata += `\n* Tags:`
+      for (const tag of feedEntry.content.tags) {
+        metadata += ` [[${tag.name}]]`
+      }
+    }
+
     metadata += '\n';
     return metadata;
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -222,6 +222,10 @@ ${annotations.map(this._renderAnnotation).join("\n")}
       metadata += `\n* Author: [[${feedEntry.content.author.any_name}]]`;
     }
 
+    if (feedEntry.content.publisher) {
+      metadata += `\n* Publisher: [[${feedEntry.content.publisher.any_name}]]`;
+    }
+
     metadata += '\n';
     return metadata;
   }


### PR DESCRIPTION
This will add the tags and publisher in the metadata like this:
```
## Metadata
* URL: [https://www.economist.com/leaders/2022/01/22/big-techs-supersized-ambitions](https://www.economist.com/leaders/2022/01/22/big-techs-supersized-ambitions)
* Published Date: 2022-01-20
* Publisher: [[The Economist]]
* Tags: [[Big Tech]]
```

Maybe it should be configurable to use hashtags instead of brackets for tags, but in that case the spaces should be removed/replaced. I personally don't use hashtags in obsidian, so that's why I went with brackets.