### PR TITLE
protect against tag format in filenames

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,5 +3,5 @@ export const sleep = (ms: number): Promise<void> => {
 }
 
 export const toFilename = (s: string): string => {
-  return s.replace(/[/\\?%*:|"<>]/g, '-');
+  return s.replace(/[/\\?%*:|"<>#]/g, '-');
 }


### PR DESCRIPTION
This adds the `#` character to `toFilename` to protect against Obsidian interpreting part of the name as a tag.

I tested the new use case locally with this title from my own Highlight collection, `Daily Writing #11: You Already Have a Voice`

CLOSES #28 