### PR TITLE
improves filenames while preserving legacy data

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -175,9 +175,12 @@ export default class MatterPlugin extends Plugin {
       await fs.mkdir(this.settings.dataDir);
     }
 
-    const entryName = await this._generateEntryName(feedEntry);
-    const entryPath = this._getPath(entryName);
+    let entryName = Object.keys(this.settings.contentMap).find(key => this.settings.contentMap[key] === feedEntry.id);
+    if (!entryName) {
+      entryName = await this._generateEntryName(feedEntry);
+    }
 
+    const entryPath = this._getPath(entryName);
     if (await fs.exists(entryPath)) {
       const after = new Date(this.settings.lastSync);
       const content = await fs.read(entryPath);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,5 +3,5 @@ export const sleep = (ms: number): Promise<void> => {
 }
 
 export const toFilename = (s: string): string => {
-  return s.replace(/[/\\%*|"<>#]/g, '-');
+  return s.replace(/[/\\?%*:|"<>#]/g, '-');
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,5 +3,5 @@ export const sleep = (ms: number): Promise<void> => {
 }
 
 export const toFilename = (s: string): string => {
-  return s.replace(/[/\\?%*:|"<>]/g, '-');
+  return s.replace(/[/\\%*|"<>#]/g, '-');
 }


### PR DESCRIPTION
@philoserf I need to make a couple of adjustments to #29 in order to prevent duplicates.

Changes:
* `#` should not be allowed in filenames
* ~~`?` and `:` should be allowed in filenames (went ahead and added this while we were here)~~ Jumped the gun here, those aren't supported in windows.
* If an entry already exists with the old filename, we should not generate a new file with the new name.

Does this look good to you?