### PR TITLE
Fixed url metadata

### DIFF
--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -14,7 +14,7 @@ const LAYOUT_TEMPLATE = `
 
 const METADATA_TEMPLATE = `
 ## Metadata
-* URL: [{{url}}](url)
+* URL: [{{url}}]({{url}})
 {% if author %}
 * Author: {{author}}
 {% endif %}


### PR DESCRIPTION
Fixed a bug in the url metadata causing the link to create a page called "url" instead of visiting the Web link